### PR TITLE
fix(splashscreen): Make logo fit within splashscreen

### DIFF
--- a/src/lib/components/SomeOtherTab.svelte
+++ b/src/lib/components/SomeOtherTab.svelte
@@ -40,5 +40,7 @@
 <style>
   img {
     width: 60%;
+    max-width: 90vw;
+		max-height: 90vh;
   }
 </style>

--- a/src/routes/components/Splash/+page.svelte
+++ b/src/routes/components/Splash/+page.svelte
@@ -47,6 +47,8 @@
 <style>
 	img {
 		width: 60%;
+		max-width: 90vw;
+		max-height: 90vh;
 	}
 
 	div {

--- a/static/assets/src/components/Splash/+page.svelte
+++ b/static/assets/src/components/Splash/+page.svelte
@@ -47,6 +47,8 @@
 <style>
 	img {
 		width: 60%;
+		max-width: 90vw;
+		max-height: 90vh;
 	}
 
 	div {


### PR DESCRIPTION
When the splashscreen loads the logo is too tall, so it is not visible. This commit makes sure that the logo is not taller than the viewable window area. It hasn't been tested. You might want to kick it down to 90vh, so it doesn't go right to the edge. 

P.S. I was listening to a podcast when I was doing this, and they started talking about Primus 😆