### PR TITLE
Stripping the trailing backslashes off the current path in IonTabs.svelte

### DIFF
--- a/components/IonTabs.svelte
+++ b/components/IonTabs.svelte
@@ -20,9 +20,10 @@
 
   // we need relative path for the goto to function properly and to allow for relative tab definitions
   const { pathname } = $page.url;
-  const pathSplit = pathname.split("/");
+  const cleanedPath = pathname.replace(/\/+$/, ''); // Strip trailing slashes, so we can get the last part of the path correctly. (e.g. /pages/homepage/ -> /pages/homepage)
+  const pathSplit = cleanedPath.split("/");
   let currentTabName = pathSplit[pathSplit.length - 1]; // we don't want to use at(-1) because of old browsers
-  const relativePath = pathname.replace(currentTabName, "");
+  let relativePath = cleanedPath.replace(currentTabName, "");
 
   // we need to capture the router changes - to support a-href navigation and other stuff
   $: if ($navigating && $navigating.to) {


### PR DESCRIPTION
There's been an issue with the tab bar navigation for a while, where if the current url is for example `pages/homepage/`, with homepage being a tab page, navigating through the tabbar to a new page eg. `pages/notifications` would lead to a 404 error after navigating to `pages/homepage/notifications` instead.

Noticed in the code that during the splitting of the current path, a trailing backslash would lead to the current tab variable having an empty string, instead of, in this case containing the actual current tab which should've been `homepage`.

The workaround proposed here is to use regex which matches trailing backslashes (one or more) and removes them, before continuing with the rest of the path splitting process.